### PR TITLE
Add kerl to utils, fix webmachine url and delete deprecated sinan

### DIFF
--- a/ErlangBookmarks.md
+++ b/ErlangBookmarks.md
@@ -64,6 +64,7 @@
 
  * [A sophisticated build-tool for Erlang projects that follows OTP principles](https://github.com/rebar/rebar)
  * [A repository for publishing packages for BEAM-based languages](http://expm.co/)
+ * [Sinan is a build tool designed to build Erlang/OTP Projects, Releases and Applications. (Deprecated)](https://github.com/erlware-deprecated/sinan)
  * [Erlang package manager](https://github.com/agner/agner)
 
 ## Editors and IDE's


### PR DESCRIPTION
Sinan is deprecated and moved to https://github.com/erlware-deprecated/sinan. So I think we should delete it.
