### PR TITLE
remove erlang-otp-for-beginners duplication

### DIFF
--- a/ErlangBookmarks.md
+++ b/ErlangBookmarks.md
@@ -12,7 +12,6 @@
  * [The Erlang Rationale](http://vidiowiki.com/media/paper/0m-V9dOL0AeY%20The_Erlang_Rationale.pdf)
  * [Making Reliable Distributed Systems in the Presence of software errors](http://www.sics.se/~joe/thesis/armstrong_thesis_2003.pdf)
  * [A little Erlang Tutorial](http://wrongnotes.blogspot.com/2007/09/little-erlang.html)
- * [Erlang OTP for beginners – Part I](http://pingbacks.wordpress.com/2012/12/13/erlang-otp-for-beginners-part-i/)
  * [Thinking in Erlang](http://ru.scribd.com/doc/44221/Thinking-in-Erlang)
  * [An Open Letter to the Erlang Beginner (or Onlooker)](http://ferd.ca/an-open-letter-to-the-erlang-beginner-or-onlooker.html)
  * [Erlang is not a Concurrent Functional Programming Language](http://www.javalimit.com/2011/05/erlang-is-not-a-concurrent-functional-programming-language.html)


### PR DESCRIPTION
this is the old one and new one is http://blog.bot.co.za/en/article/349/an-erlang-otp-tutorial-for-beginners and its already exist
