### PR TITLE
Fix URL

### DIFF
--- a/ErlangBookmarks.md
+++ b/ErlangBookmarks.md
@@ -341,5 +341,5 @@
   * [Kha - continuous integration server in Erlang.](https://github.com/greenelephantlabs/kha)
   * [Logplex - syslog log router](https://github.com/heroku/logplex)
   * [Chef - configuration management software](http://www.getchef.com)
-  * [VerneMQ - MQTT message broker](https://verne.mq)
+  * [VerneMQ - MQTT message broker](https://vernemq.com)
 


### PR DESCRIPTION
The verne.mq domain is no longer the official VerneMQ domain and is replaced by the vernemq.com domain.